### PR TITLE
feat: settings & smart mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ Sanitize It allows you to quickly remove tracking information from the current p
 
 ## How It Works
 
-Click the Sanitize It icon on any page to strip tracking parameters and copy the clean URL to your clipboard. The page stays as-is — you just get a clean link to share.
+Click the Sanitize It icon on any page to strip tracking parameters and copy the clean URL to your clipboard. By default, the page stays as-is — you just get a clean link to share.
 
-Want to also refresh the page with the clean URL? Use **Shift+Click** (Firefox) or the keyboard shortcut.
+Prefer to also refresh the page with the clean URL? You can change the default click behavior in **Settings** (right-click the extension icon → Options). **Shift+Click** (Firefox) always does the opposite of your chosen default.
+
+You can also use keyboard shortcuts for either action — see below.
 
 ![CleanShot 2024-08-05 at 22 12 19@2x](https://github.com/user-attachments/assets/3532bcce-1974-4915-8b28-11cdeb7a39d8)
 
@@ -40,7 +42,8 @@ Sanitize It 2.0 is a single codebase that supports both Chrome and Firefox (and 
 | Feature | Chrome / Edge | Firefox |
 |---|---|---|
 | Click to sanitize + copy | Yes | Yes |
-| Shift+Click to refresh | No (Chrome limitation) | Yes |
+| Configurable default action | Yes | Yes |
+| Shift+Click to invert default | No (Chrome limitation) | Yes |
 | Keyboard shortcuts | Yes | Yes |
 | Minimum version | Chrome 88+ | Firefox 121+ |
 
@@ -70,9 +73,11 @@ Sanitize It requests a few permissions in the `manifest.json` file.
 
 `tabs` allows the extension access to the tabs API, allowing it to interact with the browser's tab system. This permission is used to query the active tab for keyboard shortcut commands.
 
+`storage` allows the extension to save your preferences (like the default click behavior) using the browser's built-in extension storage. This data syncs across your devices if you're signed into your browser.
+
 #### Privacy
 
-Sanitize It runs completely locally in your browser. It does not collect any analytics, it does not store any information about your tabs or browser history, it does not send any data back for processing or analysis. Your data is yours and yours alone.
+Sanitize It runs completely locally in your browser. The only data it stores is your settings preference (default click behavior), which is kept in your browser's extension storage. It does not collect any analytics, it does not store any information about your tabs or browser history, it does not send any data back for processing or analysis. Your data is yours and yours alone.
 
 ## Installing Sanitize It
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Click the Sanitize It icon on any page to strip tracking parameters and copy the
 
 Prefer to also refresh the page with the clean URL? You can change the default click behavior in **Settings** (right-click the extension icon → Options). **Shift+Click** (Firefox) always does the opposite of your chosen default.
 
-You can also use keyboard shortcuts for either action — see below.
+You can also use keyboard shortcuts for either action—see below.
 
-![CleanShot 2024-08-05 at 22 12 19@2x](https://github.com/user-attachments/assets/3532bcce-1974-4915-8b28-11cdeb7a39d8)
+![Toasts](https://cdn.cottle.cloud/tinyextensions/toasts.gif)
 
 ## Keyboard Shortcuts
 
@@ -28,10 +28,22 @@ You can customize these shortcuts:
 - **Firefox:** `about:addons` → gear icon → Manage Extension Shortcuts
 - **Edge:** `edge://extensions/shortcuts`
 
+## Settings & Smart Mode
+
+The Sanitize It settings panel (`right-click` the extension icon → `Options`) let's you choose the default behavior when you `left click` the Sanitize It icon. 
+
+Smart mode is enabled by default. It strips tracking parameters while preserving the ones that actually make the page work. For example, on YouTube it keeps the video ID (`v=`) and playlist info but removes tracking like `si=` and `feature=`.
+
+Supported sites include `YouTube`, `Google`, `Kagi`, `Bing`, `DuckDuckGo`, `Yahoo`, and `Amazon`. Sites not on the list get full aggressive cleaning. This list is relatively small, please open an issue if you would like an additional site supported with what information you can.
+
+You can turn smart mode off in **Settings** if you prefer to strip everything from every site.
+
+![Settings](https://cdn.cottle.cloud/tinyextensions/settings.gif)
+
 ## What Gets Removed
 
 Sanitize It strips the following from URLs:
-- **Query parameters** — everything after `?` (e.g., `?utm_source=...`, `?ref=...`, `?fbclid=...`)
+- **Query parameters** — everything after `?` (e.g., `?utm_source=...`, `?ref=...`, `?fbclid=...`). With smart mode on, essential parameters are preserved on supported sites.
 - **Ref paths** — `/ref/...` and `/ref=...` segments in the URL path (common on Amazon)
 - **Hash fragments** — everything after `#`
 
@@ -43,6 +55,7 @@ Sanitize It 2.0 is a single codebase that supports both Chrome and Firefox (and 
 |---|---|---|
 | Click to sanitize + copy | Yes | Yes |
 | Configurable default action | Yes | Yes |
+| Smart mode | Yes | Yes |
 | Shift+Click to invert default | No (Chrome limitation) | Yes |
 | Keyboard shortcuts | Yes | Yes |
 | Minimum version | Chrome 88+ | Firefox 121+ |
@@ -73,11 +86,11 @@ Sanitize It requests a few permissions in the `manifest.json` file.
 
 `tabs` allows the extension access to the tabs API, allowing it to interact with the browser's tab system. This permission is used to query the active tab for keyboard shortcut commands.
 
-`storage` allows the extension to save your preferences (like the default click behavior) using the browser's built-in extension storage. This data syncs across your devices if you're signed into your browser.
+`storage` allows the extension to save your preferences (like the default click behavior and smart mode) using the browser's built-in extension storage. This data syncs across your devices if you're signed into your browser.
 
 #### Privacy
 
-Sanitize It runs completely locally in your browser. The only data it stores is your settings preference (default click behavior), which is kept in your browser's extension storage. It does not collect any analytics, it does not store any information about your tabs or browser history, it does not send any data back for processing or analysis. Your data is yours and yours alone.
+Sanitize It runs completely locally in your browser. The only data it stores are your settings preferences (default click behavior and smart mode), which are kept in your browser's extension storage. It does not collect any analytics, it does not store any information about your tabs or browser history, it does not send any data back for processing or analysis. Your data is yours and yours alone.
 
 ## Installing Sanitize It
 

--- a/background.js
+++ b/background.js
@@ -28,11 +28,11 @@ api.runtime.setUninstallURL('https://tinyextensions.com/uninstall.html?ext=sanit
 api.action.onClicked.addListener((tab, info) => {
   const shiftHeld = !!(info && info.modifiers && info.modifiers.includes('Shift'));
 
-  api.storage.sync.get({ defaultAction: 'copy' }).then((result) => {
+  api.storage.sync.get({ defaultAction: 'copy', smartMode: true }).then((result) => {
     const defaultIsRefresh = result.defaultAction === 'copyRefresh';
     const shouldRefresh = shiftHeld ? !defaultIsRefresh : defaultIsRefresh;
     console.log('Extension icon clicked (default=' + result.defaultAction + (shiftHeld ? ', Shift' : '') + ')');
-    sanitize(tab, shouldRefresh);
+    sanitize(tab, shouldRefresh, result.smartMode);
   });
 });
 
@@ -42,16 +42,53 @@ api.commands.onCommand.addListener((command) => {
     if (tabs[0]) {
       const shouldRefresh = command === 'sanitize-refresh';
       console.log('Command: ' + command);
-      sanitize(tabs[0], shouldRefresh);
+      api.storage.sync.get({ smartMode: true }).then((result) => {
+        sanitize(tabs[0], shouldRefresh, result.smartMode);
+      });
     }
   });
 });
 
-function sanitize(tab, shouldRefresh) {
-  let url = new URL(tab.url);
+// Site-specific allowlists: only these query params are preserved (everything else is stripped).
+// Sites not listed here get full aggressive stripping (all query params removed).
+const SITE_RULES = {
+  'www.youtube.com':   ['v', 'list', 'index', 't', 'search_query'],
+  'youtube.com':       ['v', 'list', 'index', 't', 'search_query'],
+  'youtu.be':          ['t'],
+  'music.youtube.com': ['v', 'list', 'index', 't'],
+  'www.google.com':    ['q', 'tbm', 'tbs', 'udm'],
+  'google.com':        ['q', 'tbm', 'tbs', 'udm'],
+  'search.yahoo.com':  ['p'],
+  'www.bing.com':      ['q'],
+  'duckduckgo.com':    ['q'],
+  'kagi.com':          ['q', 'l', 'r', 'order', 'dr', 'verbatim'],
+  'www.amazon.com':    ['dp', 's', 'k'],
+  'www.amazon.co.uk':  ['dp', 's', 'k'],
+};
 
-  // Remove everything after '?'
-  url.search = '';
+function sanitize(tab, shouldRefresh, smartMode) {
+  let url = new URL(tab.url);
+  const originalUrl = tab.url;
+  const hostname = url.hostname;
+  const hasRules = SITE_RULES.hasOwnProperty(hostname);
+  let usedSmartMode = false;
+
+  if (smartMode !== false && hasRules) {
+    // Keep only allowlisted params for this site
+    usedSmartMode = true;
+    const allowed = SITE_RULES[hostname];
+    const filtered = new URLSearchParams();
+    for (const [key, value] of url.searchParams) {
+      if (allowed.includes(key)) {
+        filtered.set(key, value);
+      }
+    }
+    const qs = filtered.toString();
+    url.search = qs ? '?' + qs : '';
+  } else {
+    // Aggressive: strip all query params
+    url.search = '';
+  }
 
   // Remove ref parameters from the pathname
   let newPathname = url.pathname.replace(/\/ref\/.*$/, '');
@@ -62,6 +99,7 @@ function sanitize(tab, shouldRefresh) {
   url.hash = '';
 
   const sanitizedUrl = url.toString();
+  const wasChanged = sanitizedUrl !== originalUrl;
   console.log('Sanitized URL:', sanitizedUrl);
 
   // Inject script on the CURRENT page while activeTab permission is still valid.
@@ -69,14 +107,14 @@ function sanitize(tab, shouldRefresh) {
   api.scripting.executeScript({
     target: { tabId: tab.id },
     func: copyAndNotify,
-    args: [sanitizedUrl, shouldRefresh]
+    args: [sanitizedUrl, shouldRefresh, usedSmartMode, wasChanged]
   });
 }
 
 // Single injected function that handles clipboard + notification in the page context.
 // This avoids serializing Promise results back to the background script, which
 // Firefox cannot do reliably with scripting.executeScript.
-function copyAndNotify(sanitizedUrl, shouldRefresh) {
+function copyAndNotify(sanitizedUrl, shouldRefresh, usedSmartMode, wasChanged) {
 
   function copyToClipboard(text) {
     if (navigator.clipboard && navigator.clipboard.writeText) {
@@ -175,9 +213,16 @@ function copyAndNotify(sanitizedUrl, shouldRefresh) {
 
   // Run clipboard, show toast, then optionally navigate
   copyToClipboard(sanitizedUrl).then((success) => {
-    const msg = success
-      ? (shouldRefresh ? 'Sanitized and copied! Refreshing...' : 'Sanitized URL copied to clipboard!')
-      : 'URL sanitized, but copying to clipboard failed.';
+    let msg;
+    if (!success) {
+      msg = 'URL sanitized, but copying to clipboard failed.';
+    } else if (!wasChanged) {
+      msg = shouldRefresh ? 'URL already clean, copied! Refreshing...' : 'URL already clean, copied to clipboard!';
+    } else if (usedSmartMode) {
+      msg = shouldRefresh ? 'Copied! (tracking removed, kept essential params) Refreshing...' : 'Copied! (tracking removed, kept essential params)';
+    } else {
+      msg = shouldRefresh ? 'Sanitized and copied! Refreshing...' : 'Sanitized URL copied to clipboard!';
+    }
     showNotification(msg, !success);
   }).catch(() => {
     showNotification('URL sanitized, but an error occurred while trying to copy.', true);

--- a/background.js
+++ b/background.js
@@ -24,11 +24,16 @@ api.runtime.onInstalled.addListener((details) => {
 });
 api.runtime.setUninstallURL('https://tinyextensions.com/uninstall.html?ext=sanitizeit');
 
-// Icon click: copy only (Firefox Shift+Click = copy + refresh)
+// Icon click: behaviour depends on user preference (Shift inverts the default)
 api.action.onClicked.addListener((tab, info) => {
-  const shouldRefresh = !!(info && info.modifiers && info.modifiers.includes('Shift'));
-  console.log('Extension icon clicked' + (shouldRefresh ? ' (Shift+Click)' : ''));
-  sanitize(tab, shouldRefresh);
+  const shiftHeld = !!(info && info.modifiers && info.modifiers.includes('Shift'));
+
+  api.storage.sync.get({ defaultAction: 'copy' }).then((result) => {
+    const defaultIsRefresh = result.defaultAction === 'copyRefresh';
+    const shouldRefresh = shiftHeld ? !defaultIsRefresh : defaultIsRefresh;
+    console.log('Extension icon clicked (default=' + result.defaultAction + (shiftHeld ? ', Shift' : '') + ')');
+    sanitize(tab, shouldRefresh);
+  });
 });
 
 // Keyboard shortcuts (work on both Chrome and Firefox)

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DIST_DIR="$SCRIPT_DIR/dist"
-SHARED_FILES="background.js icon16.png icon48.png icon128.png"
+SHARED_FILES="background.js options.html options.css options.js icon16.png icon48.png icon128.png"
 
 # Read version from root manifest.json
 VERSION=$(sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' "$SCRIPT_DIR/manifest.json")
@@ -34,7 +34,8 @@ cat > "$DIST_DIR/chrome/manifest.json" << EOF
     "activeTab",
     "scripting",
     "clipboardWrite",
-    "tabs"
+    "tabs",
+    "storage"
   ],
   "action": {
     "default_icon": {
@@ -50,6 +51,10 @@ cat > "$DIST_DIR/chrome/manifest.json" << EOF
     "16": "icon16.png",
     "48": "icon48.png",
     "128": "icon128.png"
+  },
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
   },
   "commands": {
     "sanitize-copy": {
@@ -79,7 +84,8 @@ cat > "$DIST_DIR/firefox/manifest.json" << EOF
     "activeTab",
     "scripting",
     "clipboardWrite",
-    "tabs"
+    "tabs",
+    "storage"
   ],
   "action": {
     "default_icon": {
@@ -95,6 +101,10 @@ cat > "$DIST_DIR/firefox/manifest.json" << EOF
     "16": "icon16.png",
     "48": "icon48.png",
     "128": "icon128.png"
+  },
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
   },
   "commands": {
     "sanitize-copy": {

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,8 @@
     "activeTab",
     "scripting",
     "clipboardWrite",
-    "tabs"
+    "tabs",
+    "storage"
   ],
   "action": {
     "default_icon": {
@@ -23,6 +24,10 @@
     "16": "icon16.png",
     "48": "icon48.png",
     "128": "icon128.png"
+  },
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
   },
   "commands": {
     "sanitize-copy": {

--- a/options.css
+++ b/options.css
@@ -1,0 +1,264 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+/* Light theme (default) */
+:root {
+  --bg: #f5f5f5;
+  --card-bg: #fff;
+  --card-border: rgba(0, 0, 0, 0.08);
+  --card-shadow: 0 4px 24px rgba(0, 0, 0, 0.06);
+  --heading: #111;
+  --text: #333;
+  --text-secondary: #666;
+  --text-muted: #999;
+  --text-faint: #bbb;
+  --radio-border: #ccc;
+  --radio-checked: #111;
+  --row-hover: rgba(0, 0, 0, 0.03);
+  --divider: rgba(0, 0, 0, 0.06);
+  --link: #666;
+  --link-hover: #111;
+  --sep: #ccc;
+}
+
+/* Dark theme */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #111;
+    --card-bg: #1a1a1a;
+    --card-border: rgba(255, 255, 255, 0.08);
+    --card-shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
+    --heading: #fff;
+    --text: #e0e0e0;
+    --text-secondary: #999;
+    --text-muted: #666;
+    --text-faint: #555;
+    --radio-border: #444;
+    --radio-checked: #fff;
+    --row-hover: rgba(255, 255, 255, 0.04);
+    --divider: rgba(255, 255, 255, 0.06);
+    --link: #999;
+    --link-hover: #fff;
+    --sep: #333;
+  }
+}
+
+body {
+  background: var(--bg);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 60px 20px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  color: var(--text);
+}
+
+.options-container {
+  background: var(--card-bg);
+  border-radius: 16px;
+  border: 1px solid var(--card-border);
+  box-shadow: var(--card-shadow);
+  padding: 32px;
+  max-width: 420px;
+  width: 100%;
+}
+
+/* Header */
+.options-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 28px;
+}
+
+.options-icon {
+  width: 36px;
+  height: 36px;
+}
+
+.options-header h1 {
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: -0.025em;
+  color: var(--heading);
+}
+
+/* Section */
+.options-section {
+  margin-bottom: 24px;
+}
+
+.options-section h2 {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-secondary);
+  margin-bottom: 12px;
+}
+
+.options-description {
+  font-size: 13px;
+  font-weight: 400;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin-bottom: 16px;
+}
+
+/* Option rows */
+.option-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.option-row:hover {
+  background: var(--row-hover);
+}
+
+.option-row + .option-row {
+  margin-top: 2px;
+}
+
+/* Custom radio button */
+.option-row input[type="radio"] {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  min-width: 18px;
+  border: 2px solid var(--radio-border);
+  border-radius: 50%;
+  margin-top: 1px;
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+  position: relative;
+}
+
+.option-row input[type="radio"]:checked {
+  border-color: var(--radio-checked);
+}
+
+.option-row input[type="radio"]:checked::after {
+  content: '';
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 8px;
+  height: 8px;
+  background: var(--radio-checked);
+  border-radius: 50%;
+}
+
+.option-row input[type="radio"]:focus-visible {
+  outline: 2px solid var(--radio-checked);
+  outline-offset: 2px;
+}
+
+.option-label {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.option-label strong {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text);
+}
+
+.option-detail {
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+/* Note */
+.options-note {
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--text-faint);
+  line-height: 1.6;
+  padding-top: 16px;
+  border-top: 1px solid var(--divider);
+}
+
+/* Footer */
+.options-footer {
+  margin-top: 24px;
+  padding-top: 16px;
+  border-top: 1px solid var(--divider);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-faint);
+}
+
+.options-footer a {
+  color: var(--link);
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+.options-footer a:hover {
+  color: var(--link-hover);
+}
+
+.footer-sep {
+  color: var(--sep);
+}
+
+/* Save toast — matches the in-page toast from background.js */
+@keyframes toast-in {
+  from { opacity: 0; transform: translateX(-50%) translateY(-8px) scale(0.96); }
+  to   { opacity: 1; transform: translateX(-50%) translateY(0) scale(1); }
+}
+
+@keyframes toast-out {
+  from { opacity: 1; transform: translateX(-50%) translateY(0) scale(1); }
+  to   { opacity: 0; transform: translateX(-50%) translateY(-8px) scale(0.96); }
+}
+
+.save-indicator {
+  position: fixed;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(20, 40, 20, 0.88);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  backdrop-filter: blur(20px) saturate(180%);
+  color: #6FCF6A;
+  padding: 10px 18px;
+  border-radius: 10px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  line-height: 1.4;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18),
+              0 1px 3px rgba(0, 0, 0, 0.12),
+              inset 0 0.5px 0 rgba(255, 255, 255, 0.08);
+  border: 0.5px solid rgba(111, 207, 106, 0.15);
+  text-align: center;
+  opacity: 0;
+  pointer-events: none;
+  z-index: 1000;
+}
+
+.save-indicator.visible {
+  animation: toast-in 0.25s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+.save-indicator.hiding {
+  animation: toast-out 0.35s cubic-bezier(0.4, 0, 1, 1) forwards;
+}

--- a/options.css
+++ b/options.css
@@ -22,6 +22,9 @@
   --link: #666;
   --link-hover: #111;
   --sep: #ccc;
+  --toggle-bg: #ccc;
+  --toggle-bg-on: #111;
+  --toggle-knob: #fff;
 }
 
 /* Dark theme */
@@ -43,6 +46,9 @@
     --link: #999;
     --link-hover: #fff;
     --sep: #333;
+    --toggle-bg: #333;
+    --toggle-bg-on: #fff;
+    --toggle-knob: #111;
   }
 }
 
@@ -180,6 +186,74 @@ body {
   font-weight: 400;
   color: var(--text-muted);
   line-height: 1.4;
+}
+
+/* Toggle row */
+.toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.toggle-row:hover {
+  background: var(--row-hover);
+}
+
+/* Toggle switch */
+.toggle-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle-track {
+  position: relative;
+  flex-shrink: 0;
+  width: 40px;
+  height: 24px;
+  background: var(--toggle-bg);
+  border-radius: 12px;
+  transition: background 0.2s ease;
+}
+
+.toggle-track::after {
+  content: '';
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  background: var(--toggle-knob);
+  border-radius: 50%;
+  transition: transform 0.2s ease;
+}
+
+.toggle-input:checked + .toggle-track {
+  background: var(--toggle-bg-on);
+}
+
+.toggle-input:checked + .toggle-track::after {
+  transform: translateX(16px);
+}
+
+.toggle-input:focus-visible + .toggle-track {
+  outline: 2px solid var(--radio-checked);
+  outline-offset: 2px;
+}
+
+.toggle-note {
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--text-faint);
+  line-height: 1.5;
+  margin-top: 8px;
+  padding-left: 14px;
 }
 
 /* Note */

--- a/options.html
+++ b/options.html
@@ -34,8 +34,21 @@
       </label>
     </div>
 
+    <div class="options-section">
+      <h2>URL Cleaning</h2>
+      <label class="toggle-row">
+        <span class="option-label">
+          <strong>Smart mode</strong>
+          <span class="option-detail">Preserve functional parameters on known sites (YouTube video IDs, timestamps, Google search queries, etc.)</span>
+        </span>
+        <input type="checkbox" id="smartMode" class="toggle-input">
+        <span class="toggle-track"></span>
+      </label>
+      <p class="toggle-note">When off, all query parameters are removed from every site.</p>
+    </div>
+
     <p class="options-note">
-      Keyboard shortcuts are not affected by this setting.<br>
+      Keyboard shortcuts are not affected by these settings.<br>
       Alt+Shift+X always copies only. Alt+Shift+R always copies and refreshes.
     </p>
 

--- a/options.html
+++ b/options.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sanitize It — Settings</title>
+  <link rel="stylesheet" href="options.css">
+</head>
+<body>
+  <div class="options-container">
+    <div class="options-header">
+      <img src="icon48.png" alt="" class="options-icon">
+      <h1>Sanitize It</h1>
+    </div>
+
+    <div class="options-section">
+      <h2>Default Click Behavior</h2>
+      <p class="options-description">Choose what happens when you click the extension icon.</p>
+
+      <label class="option-row">
+        <input type="radio" name="defaultAction" value="copy">
+        <span class="option-label">
+          <strong>Copy only</strong>
+          <span class="option-detail">Sanitize the URL and copy it to your clipboard</span>
+        </span>
+      </label>
+
+      <label class="option-row">
+        <input type="radio" name="defaultAction" value="copyRefresh">
+        <span class="option-label">
+          <strong>Copy + Refresh</strong>
+          <span class="option-detail">Sanitize the URL, copy it, and refresh the page</span>
+        </span>
+      </label>
+    </div>
+
+    <p class="options-note">
+      Keyboard shortcuts are not affected by this setting.<br>
+      Alt+Shift+X always copies only. Alt+Shift+R always copies and refreshes.
+    </p>
+
+    <div class="save-indicator" id="saveIndicator">Settings saved</div>
+
+    <div class="options-footer">
+      <span>Built by <a href="https://seth.social" target="_blank" rel="noopener">Seth Cottle</a></span>
+      <span class="footer-sep">&middot;</span>
+      <a href="https://tinyextensions.com/sanitizeit" target="_blank" rel="noopener">Website</a>
+      <span class="footer-sep">&middot;</span>
+      <a href="https://github.com/sethcottle/sanitize-it" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </div>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,34 @@
+// Cross-browser namespace: Chrome <144 uses chrome.*, Firefox and Chrome 144+ use browser.*
+const api = typeof browser !== 'undefined' ? browser : chrome;
+
+document.addEventListener('DOMContentLoaded', () => {
+  const radios = document.querySelectorAll('input[name="defaultAction"]');
+  const saveIndicator = document.getElementById('saveIndicator');
+  let hideTimeout;
+
+  // Load current setting
+  api.storage.sync.get({ defaultAction: 'copy' }).then((result) => {
+    const radio = document.querySelector(
+      'input[name="defaultAction"][value="' + result.defaultAction + '"]'
+    );
+    if (radio) radio.checked = true;
+  });
+
+  // Save on change
+  radios.forEach((radio) => {
+    radio.addEventListener('change', (e) => {
+      api.storage.sync.set({ defaultAction: e.target.value }).then(() => {
+        // Show save indicator
+        clearTimeout(hideTimeout);
+        saveIndicator.classList.remove('hiding');
+        saveIndicator.classList.add('visible');
+
+        hideTimeout = setTimeout(() => {
+          saveIndicator.classList.remove('visible');
+          saveIndicator.classList.add('hiding');
+          setTimeout(() => saveIndicator.classList.remove('hiding'), 300);
+        }, 1500);
+      });
+    });
+  });
+});

--- a/options.js
+++ b/options.js
@@ -3,32 +3,40 @@ const api = typeof browser !== 'undefined' ? browser : chrome;
 
 document.addEventListener('DOMContentLoaded', () => {
   const radios = document.querySelectorAll('input[name="defaultAction"]');
+  const smartModeToggle = document.getElementById('smartMode');
   const saveIndicator = document.getElementById('saveIndicator');
   let hideTimeout;
 
-  // Load current setting
-  api.storage.sync.get({ defaultAction: 'copy' }).then((result) => {
+  function showSaved() {
+    clearTimeout(hideTimeout);
+    saveIndicator.classList.remove('hiding');
+    saveIndicator.classList.add('visible');
+
+    hideTimeout = setTimeout(() => {
+      saveIndicator.classList.remove('visible');
+      saveIndicator.classList.add('hiding');
+      setTimeout(() => saveIndicator.classList.remove('hiding'), 300);
+    }, 1500);
+  }
+
+  // Load current settings
+  api.storage.sync.get({ defaultAction: 'copy', smartMode: true }).then((result) => {
     const radio = document.querySelector(
       'input[name="defaultAction"][value="' + result.defaultAction + '"]'
     );
     if (radio) radio.checked = true;
+    smartModeToggle.checked = result.smartMode;
   });
 
-  // Save on change
+  // Save default action on change
   radios.forEach((radio) => {
     radio.addEventListener('change', (e) => {
-      api.storage.sync.set({ defaultAction: e.target.value }).then(() => {
-        // Show save indicator
-        clearTimeout(hideTimeout);
-        saveIndicator.classList.remove('hiding');
-        saveIndicator.classList.add('visible');
-
-        hideTimeout = setTimeout(() => {
-          saveIndicator.classList.remove('visible');
-          saveIndicator.classList.add('hiding');
-          setTimeout(() => saveIndicator.classList.remove('hiding'), 300);
-        }, 1500);
-      });
+      api.storage.sync.set({ defaultAction: e.target.value }).then(showSaved);
     });
+  });
+
+  // Save smart mode on change
+  smartModeToggle.addEventListener('change', () => {
+    api.storage.sync.set({ smartMode: smartModeToggle.checked }).then(showSaved);
   });
 });


### PR DESCRIPTION
Addressing issue #3. This adds a settings panel that allows the user to select the default action for Sanitize It and adds a new `Smart Mode` to fix sites that commonly break when using Sanitize It (like YouTube).

![Settings](https://cdn.cottle.cloud/tinyextensions/settings.gif)